### PR TITLE
Remove Use of std::enable_shared_from_this

### DIFF
--- a/src/actions/lua_chat_action_talk.hpp
+++ b/src/actions/lua_chat_action_talk.hpp
@@ -48,7 +48,7 @@ private:
 
   // Class to encapsulate a TCP connection and the data sent over it. Note
   // that this is based on the ASIO Asychronous TCP server tutorial.
-  class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
+  class tcp_connection {
   public:
     using pointer = std::shared_ptr<tcp_connection>;
 


### PR DESCRIPTION
The tcp_connection class does not require std::enable_shared_from_this,
so this commit removes it to simplify the code.