### PR TITLE
Fix to Build with Lua 5.4.2

### DIFF
--- a/src/lua_chat_lua_manager.cpp
+++ b/src/lua_chat_lua_manager.cpp
@@ -236,10 +236,14 @@ void LuaManager::ProcessLuaError(int lua_ret) {
       throw std::runtime_error("syntax error: " + error_message);
     case LUA_ERRMEM:
       throw std::runtime_error("out-of-memory: " + error_message);
-    case LUA_ERRGCMM:
-      throw std::runtime_error("garbage collection: " + error_message);
     case LUA_ERRRUN:
       throw std::runtime_error("runtime error: " + error_message);
+    case LUA_ERRERR:
+      throw std::runtime_error("error: " + error_message);
+#if LUA_VERSION_NUM == 503
+    case LUA_ERRGCMM:
+      throw std::runtime_error("garbage collection: " + error_message);
+#endif
   }
 };
 


### PR DESCRIPTION
One of the #defines in lua.h has changed slightly between Lua 5.3 and 5.4. This commit adds a fix for this.